### PR TITLE
release/1.0.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, development ]
+  pull_request:
+    branches: [ main, development ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install .  # Installs your apc package (editable install if setup.py exists)
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          python -m unittest discover -s apc/tests -p "test_*.py" -v

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This package is for age-period-cohort and extended chain-ladder analysis. It all
 
 ## Latest changes
 
+Version 1.0.3 fixes bugs introduced by dependency updates. Now requires Python >= 3.10.
+
 Version 1.0.2 fixes some bugs introduced by pandas 0.25.0. apc 1.0.2 now requires pandas >=0.24.0. Further, the version refactors some of the unittests and removes deprecated behavior.
 
 Version 1.0.1 fixes some typos and refactors production code.

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -1797,9 +1797,15 @@ class Model:
         if (C_coef == 0).all():
             C_coef = C_coef.replace(0, np.nan)
 
-        A_cov = A_design.dot(age_cov).dot(A_design.T)
-        B_cov = B_design.dot(per_cov).dot(B_design.T)
-        C_cov = C_design.dot(coh_cov).dot(C_design.T)
+        # handling absence of _cov matrices (if didn't estimate those components)
+        # explicitly filling with np.nan in the else case is needed for downstream
+        # consistency.
+        A_cov = A_design.dot(age_cov).dot(A_design.T) if not age_cov.empty \
+            else pd.DataFrame(np.nan, index=A_design.index, columns=A_design.index)
+        B_cov = B_design.dot(per_cov).dot(B_design.T) if not per_cov.empty \
+            else pd.DataFrame(np.nan, index=B_design.index, columns=B_design.index)
+        C_cov = C_design.dot(coh_cov).dot(C_design.T) if not coh_cov.empty \
+            else pd.DataFrame(np.nan, index=C_design.index, columns=C_design.index)
 
         A_stderr = pd.Series(
             np.sqrt(np.diag(A_cov)), index=A_coef.index).replace(0, np.nan)

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -2215,8 +2215,8 @@ class Model:
         if predictor in ('C', 'tC'):
             ax[1, 2].set_title('cohort linear trend')
 
-        err_plot(pd.Series([get_coefs('level')[0]] * 2),
-                 pd.Series([get_stderr('level')[0]] * 2),
+        err_plot(pd.Series([get_coefs('level').iloc[0]] * 2),
+                 pd.Series([get_stderr('level').iloc[0]] * 2),
                  ax[1, 1], range(2),
                  'age, period,cohort', 'level', around_coef)
         ax[1, 1].set_xticks([])

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -398,7 +398,7 @@ class Model:
         index_levels_per = index.levels[1]
         index_levels_coh = index.levels[2]
         index_trap = (pd.DataFrame(index.codes, index=index.names).T.
-                      loc[:, ['Age', 'Cohort']])
+                    loc[:, ['Age', 'Cohort']])
 
         I, K, J, L, n = self.I, self.K, self.J, self.L, self.n
 
@@ -417,28 +417,35 @@ class Model:
         dd_age_col = ['dd_age_{}'.format(age) for age in index_levels_age[2:]]
         dd_age = pd.DataFrame(0, index=range(n), columns=dd_age_col)
         for i in range(anchor_index):
-            dd_age.loc[slope_age == -anchor_index+i, i:anchor_index] = (
-                np.arange(1, anchor_index-i+1))
+            # handle empty case gracefully
+            if (slope_age == -anchor_index+i).any():
+                dd_age.loc[slope_age == -anchor_index+i, dd_age.columns[i:anchor_index]] = (
+                    np.arange(1, anchor_index-i+1))
         for i in range(1, I - anchor_index):
-            dd_age.loc[slope_age == i+1, anchor_index:anchor_index+i] = (
-                np.arange(i, 0, -1))
+            if (slope_age == i+1).any():
+                dd_age.loc[slope_age == i+1, dd_age.columns[anchor_index:anchor_index+i]] = (
+                    np.arange(i, 0, -1))
 
         dd_per_col = ['dd_per_{}'.format(per) for per in index_levels_per[2:]]
         dd_per = pd.DataFrame(0, index=range(n), columns=dd_per_col)
         if per_odd:
-            dd_per.loc[slope_per == -1, 0:1] = 1
+            if (slope_per == -1).any():
+                dd_per.loc[slope_per == -1, dd_per.columns[0:1]] = 1
         for j in range(J-2-per_odd):
-            dd_per.loc[slope_per == j+2, int(per_odd):j+1+int(per_odd)] = (
-                np.arange(j+1, 0, -1))
+            if (slope_per == j+2).any():
+                dd_per.loc[slope_per == j+2, dd_per.columns[int(per_odd):j+1+int(per_odd)]] = (
+                    np.arange(j+1, 0, -1))
 
         dd_coh_col = ['dd_coh_{}'.format(coh) for coh in index_levels_coh[2:]]
         dd_coh = pd.DataFrame(0, index=range(n), columns=dd_coh_col)
         for k in range(anchor_index):
-            dd_coh.loc[slope_coh == -anchor_index+k, k:anchor_index] = (
-                np.arange(1, anchor_index-k+1))
+            if (slope_coh == -anchor_index+k).any():
+                dd_coh.loc[slope_coh == -anchor_index+k, dd_coh.columns[k:anchor_index]] = (
+                    np.arange(1, anchor_index-k+1))
         for k in range(1, K - anchor_index):
-            dd_coh.loc[slope_coh == k+1, anchor_index:anchor_index+k] = (
-                np.arange(k, 0, -1))
+            if (slope_coh == k+1).any():
+                dd_coh.loc[slope_coh == k+1, dd_coh.columns[anchor_index:anchor_index+k]] = (
+                    np.arange(k, 0, -1))
 
         design_components = {
             'index': self.data_vector.index,

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -183,7 +183,8 @@ class Model:
         try:  # try to convert to integers, in case int loaded as str
             response.columns = response.columns.astype(int)
             response.index = response.index.astype(int)
-        except TypeError:
+        except (TypeError, ValueError): 
+            # pandas docs say it raises TypeError, but seems to have switched back to value error
             pass
 
         if rate is None and dose is None:

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -2395,7 +2395,7 @@ class Model:
             if lvl == 'Cell':
                 return df
             elif lvl in ('Age', 'Period', 'Cohort'):
-                return df.sum(level=lvl).sort_index()
+                return df.groupby(lvl).sum().sort_index()
             else:
                 try:
                     return pd.DataFrame(df.sum(), columns=['Total']).T
@@ -2620,8 +2620,8 @@ class Model:
         """
         flt = pd.IndexSlice[from_to[0]:from_to[1]]
 
-        response = self.data_vector['response'].sum(level=by).loc[flt]
-        fitted = self.fitted_values.sum(level=by).rename('fitted').loc[flt]
+        response = self.data_vector['response'].groupby(by).sum().loc[flt]
+        fitted = self.fitted_values.groupby(by).sum().rename('fitted').loc[flt]
         point_fc = self.forecasts[by]['point_forecast'].copy().loc[flt]
         if ic:
             ic_factor = (response.sort_index().iloc[-1]

--- a/apc/Model.py
+++ b/apc/Model.py
@@ -1897,7 +1897,7 @@ class Model:
                 np.sqrt(np.diag(C_d_cov)), index=C_coef.index
                 ).replace(0, np.nan)
 
-            level_d_design = pd.Series(0, index=index_labels)
+            level_d_design = pd.Series(0., index=index_labels)
             level_d_design.loc['level'] = 1
             level_d_design.loc[f(index_labels, 'slope_age')] = -U
             level_d_design.loc[f(index_labels, 'slope_coh')] = -U
@@ -1913,7 +1913,7 @@ class Model:
 
             if predictor in ('APC', 'AP', 'AC', 'PC', 'Ad', 'Pd', 'Cd', 'A',
                              't', 'tA'):
-                slope_age_d_design = pd.Series(0, index=index_labels)
+                slope_age_d_design = pd.Series(0., index=index_labels)
                 slope_age_d_design.loc[f(index_labels, 'slope_age')] = 1
                 slope_age_d_design.loc[f(index_labels, 'dd_age')] = (
                     (A_design.iloc[-1, :] - A_design.iloc[0, :])/(I-1)
@@ -1940,7 +1940,7 @@ class Model:
 
             if predictor in ('APC', 'AP', 'AC', 'PC', 'Ad', 'Pd', 'Cd', 'C',
                              't', 'tC'):
-                slope_coh_d_design = pd.Series(0, index=index_labels)
+                slope_coh_d_design = pd.Series(0., index=index_labels)
                 slope_coh_d_design.loc[f(index_labels, 'slope_coh')] = 1
                 slope_coh_d_design.loc[f(index_labels, 'dd_coh')] = (
                     (C_design.iloc[-1, :] - C_design.iloc[0, :])/(K-1)
@@ -1965,7 +1965,7 @@ class Model:
                 slope_coh_d_row = None
 
             if predictor in ('P', 'tP'):
-                slope_per_d_design = pd.Series(0, index=index_labels)
+                slope_per_d_design = pd.Series(0., index=index_labels)
                 slope_per_d_design.loc[f(index_labels, 'slope_per')] = 1
                 slope_per_d_design.loc[f(index_labels, 'dd_per')] = (
                     (B_design.iloc[-1, :] - B_design.iloc[0, :])/(J-1)

--- a/apc/cl_bootstrap.py
+++ b/apc/cl_bootstrap.py
@@ -39,7 +39,7 @@ def _chain_ladder(df, target_idx):
     time_adjust = coh_max - per_max + 1
 
     # row-sums in a run-off triangle
-    coh_sums = df.sum(level='Cohort')
+    coh_sums = df.groupby('Cohort').sum()
 
     # compute development factors
     dev_fctrs = []
@@ -152,9 +152,9 @@ def bootstrap_forecast(data, quantiles=[0.75, 0.9, 0.95, 0.99], B=999,
 
     fc_bootstrap = {
         'Cell': bs_oosmpl.T.describe(quantiles).T,
-        'Age': bs_oosmpl.sum(level='Age').T.describe(quantiles).T,
-        'Cohort': bs_oosmpl.sum(level='Cohort').T.describe(quantiles).T,
-        'Period': bs_oosmpl.sum(level='Period').T.describe(quantiles).T,
+        'Age': bs_oosmpl.groupby('Age').sum().T.describe(quantiles).T,
+        'Cohort': bs_oosmpl.groupby('Cohort').sum().T.describe(quantiles).T,
+        'Period': bs_oosmpl.groupby('Period').sum().T.describe(quantiles).T,
         'Total': bs_oosmpl.sum().describe(quantiles).rename('Total')
         }
 

--- a/apc/data/pre_formatted.py
+++ b/apc/data/pre_formatted.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 import pandas as pd
-from pkg_resources import resource_filename
-
+from importlib.resources import files
 
 def loss_TA():
     """
@@ -35,7 +34,7 @@ def loss_TA():
     outstanding claims. Journal of Econometrics, 23(1), 37–61.
 
     """
-    data_ta = pd.read_csv(resource_filename('apc', 'data/loss_TA.csv'),
+    data_ta = pd.read_csv(files('apc') / 'data/loss_TA.csv',
                           index_col=0)
     data_ta.index.name = 'Accident Year'
     data_ta.columns.name = 'Development Year'
@@ -89,19 +88,19 @@ def loss_VNJ(include_counts=False):
 
     """
     response_vnj = pd.read_excel(
-        resource_filename('apc', 'data/loss_VNJ.xlsx'), 'response', index_col=0
+        files('apc') / 'data/loss_VNJ.xlsx', 'response', index_col=0
         )
     response_vnj.index.name = 'Accident Year'
     response_vnj.columns.name = 'Development Year'
 
     counts_vnj = pd.read_excel(
-        resource_filename('apc', 'data/loss_VNJ.xlsx'), 'counts', index_col=0
+        files('apc') / 'data/loss_VNJ.xlsx', 'counts', index_col=0
         )
     counts_vnj.index.name = 'Accident Year'
     counts_vnj.columns.name = 'Development Year'
 
     if include_counts:
-        data_vnj = {'response': response_vnj, 'counts': data_vnj_counts}
+        data_vnj = {'response': response_vnj, 'counts': counts_vnj}
     else:
         data_vnj = response_vnj
 
@@ -143,11 +142,11 @@ def Belgian_lung_cancer():
 
     """
     lung_cases = pd.read_excel(
-        resource_filename('apc', 'data/Belgian_lung_cancer.xlsx'), 'response',
+        files('apc') / 'data/Belgian_lung_cancer.xlsx', 'response',
         index_col=0
         )
     lung_rates = pd.read_excel(
-        resource_filename('apc', 'data/Belgian_lung_cancer.xlsx'), 'rates',
+        files('apc') / 'data/Belgian_lung_cancer.xlsx', 'rates',
         index_col=0
         )
     lung_data = {'response': lung_cases, 'rate': lung_rates,
@@ -184,7 +183,7 @@ def loss_BZ():
 
     """
     data_bz = pd.read_csv(
-        resource_filename('apc', 'data/loss_BZ.csv'), index_col=0
+        files('apc') / 'data/loss_BZ.csv', index_col=0
         )
     data_bz.index.name = 'Accident Year'
     data_bz.columns.name = 'Development Year'
@@ -241,7 +240,7 @@ def asbestos(sample='2007', balanced=True):
 
     """
     asbestos = pd.read_excel(
-        resource_filename('apc', 'data/asbestos_mortality.xlsx'), sample,
+        files('apc') / 'data/asbestos_mortality.xlsx', sample,
         index_col='Period'
         )
     asbestos.columns.name = 'Age'
@@ -280,7 +279,7 @@ def loss_KN():
 
     """
     data_kn = pd.read_csv(
-        resource_filename('apc', 'data/loss_KN.csv'), index_col=0
+        files('apc') / 'data/loss_KN.csv', index_col=0
         )
     data_kn.index.name = 'Cohort'
     data_kn.columns.name = 'Age'

--- a/apc/tests/test_data_from_df.py
+++ b/apc/tests/test_data_from_df.py
@@ -1,7 +1,7 @@
 import unittest
 import pandas as pd
 import apc
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 class TestDataFromDf(unittest.TestCase):
 
@@ -47,7 +47,7 @@ class TestDataFromDf(unittest.TestCase):
         
     def test_Belgian(self):
         data = pd.read_excel(
-            resource_filename('apc', 'data/Belgian_lung_cancer.xlsx'), 
+            files('apc') / 'data/Belgian_lung_cancer.xlsx', 
             sheet_name = ['response', 'rates'], 
             index_col = 0)
         model = apc.Model()

--- a/apc/tests/test_fit.py
+++ b/apc/tests/test_fit.py
@@ -47,7 +47,7 @@ class TestFit(unittest.TestCase):
             )
         )
         self.assertAlmostEqual(
-            model.fitted_values.sum(), model.data_vector.sum()[0]
+            model.fitted_values.sum(), model.data_vector.sum().iloc[0]
         )
         
     def test_Belgian_poisson_dose_response(self):

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ with open("README.md", "r", encoding='utf8') as fh:
 
 setuptools.setup(
     name='apc',
-    version='1.0.2',
+    version='1.0.3',
     description='Age-Period-Cohort and extended Chain-Ladder Analysis',
     url='http://github.com/JonasHarnau/apc',
     author='Jonas Harnau',
     author_email='j.harnau@outlook.com',
     license='GPLv3',
     packages=setuptools.find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.10',
     install_requires=[
-        'matplotlib', 'numpy', 'pandas>=0.24.0', 'quad_form_ratio', 'seaborn',
-        'scipy', 'statsmodels'
+        'matplotlib', 'numpy', 'pandas>=2.0.0', 'quad_form_ratio', 'seaborn',
+        'scipy', 'statsmodels', 'openpyxl',
     ],
     include_package_data=True,
     classifiers=['Development Status :: 3 - Alpha'],


### PR DESCRIPTION
Bring package up to date, requiring newer pandas (and there dependency) version and working with python >= 3.10.

- Add GitHub Action to run tests
- Handle newer pandas, replacing deprecated functionality such as replacing `pd.DataFrame.sum(level="foo")` with `pd.DataFrame.groupby("foo").sum()` and addressing different handling of empty data frames in some cases. Includes addressing https://github.com/JonasHarnau/apc/issues/8 and https://github.com/JonasHarnau/apc/issues/7.
- Switch from `pkg_resources` to `importlib` to handle included data imports